### PR TITLE
Change/dont display pokemon metabox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+vendor

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "oscar/wp-dexter",
+    "authors": [
+        {
+            "name": "Oscar Sanchez",
+            "email": "osanpk@comunidad.unam.mx"
+        }
+    ],
+    "require": {
+        "php": ">=5.2"
+    },
+    "require-dev": {
+        "wp-coding-standards/wpcs": "*",
+        "wimg/php-compatibility": "*",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,231 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "16d2901e67e529125084e0c9380198d4",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "^5.3|^7",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "wimg/php-compatibility": "^8.0"
+            },
+            "suggest": {
+                "dealerdirect/qa-tools": "All the PHP QA tools you'll need"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "f.nijhof@dealerdirect.nl",
+                    "homepage": "http://workingatdealerdirect.eu",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://workingatdealerdirect.eu",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "time": "2017-12-06T16:27:17+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "d86873af43b4aa9d1f39a3601cc0cfcf02b25266"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d86873af43b4aa9d1f39a3601cc0cfcf02b25266",
+                "reference": "d86873af43b4aa9d1f39a3601cc0cfcf02b25266",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-06-06T23:58:19+00:00"
+        },
+        {
+            "name": "wimg/php-compatibility",
+            "version": "8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wimg/PHPCompatibility.git",
+                "reference": "4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wimg/PHPCompatibility/zipball/4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e",
+                "reference": "4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.2 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "PHPCompatibility\\": "PHPCompatibility/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2017-12-27T21:58:38+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "0.14.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
+                "reference": "cf6b310caad735816caef7573295f8a534374706"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/cf6b310caad735816caef7573295f8a534374706",
+                "reference": "cf6b310caad735816caef7573295f8a534374706",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2018-02-16T01:57:48+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.2"
+    },
+    "platform-dev": []
+}

--- a/css/wp-dexter-styles.css
+++ b/css/wp-dexter-styles.css
@@ -25,7 +25,8 @@
 /**POKEBOX**/
 
 .pokepostbox {
-    padding-left: 30px;
+    padding: 0 1.5em;
+    margin-top: 1em;
 }
 
 .pokebold {

--- a/inc/class-admin.php
+++ b/inc/class-admin.php
@@ -60,16 +60,15 @@ class Admin {
 	}
 
 	/**
-	 * Creates the admin menus for the plugin.
+	 * Creates the plugin's settings page in the settings menu.
 	 */
 	public function admin_menus() {
-		add_menu_page(
-			__( 'Dexter Admin page', 'wp-dexter' ),
-			__( 'Dexter', 'wp-dexter' ),
+		add_options_page(
+			__( 'WP-Dexter', 'wp-dexter' ),
+			__( 'WP-Dexter', 'wp-dexter' ),
 			'manage_options',
 			'wp-dexter',
-			array( $this, 'admin_main_page' ),
-			'dashicons-smartphone'
+			array( $this, 'render_options_page' )
 		);
 	}
 
@@ -91,51 +90,15 @@ class Admin {
 	/**
 	 * Renders the main page.
 	 */
-	public function admin_main_page() {
-		$this->admin_header();
-		//Renders the Pokemon Metabox with all display options enabled.
+	public function render_options_page() {
 		$this->admin_form_settings();
-		$this->plugin->components->metabox->display_full_metabox();
-	}
-
-	/**
-	 * Renders the header of the admin area.
-	 */
-	public function admin_header() {
-	?>
-		<div class="wrapper">
-			<h1><?php esc_html_e( 'Dexter', 'wp-dexter' ); ?></h1>
-			<p class="about description"><?php echo esc_html_e( 'Welcome PokeUser, you shall change Dexter settings in this page', 'wp-dexter' ); ?></p>
-		</div>
-	<?php
 	}
 
 	/**
 	 * Renders the admin settings.
 	 */
 	public function admin_form_settings() {
-		$wp_dexter_pokemon_generation = get_option( 'wp_dexter_pokemon_generation' );
-		?>
-		<div class="postbox pokepostbox">
-			<div class="settings">
-				<h3><?php echo esc_html_e( 'Settings', 'wp-dexter' ); ?></h3>
-				<p class="about description"><?php echo esc_html_e( 'Changes might take a while', 'wp-dexter' ); ?></p>
-			</div>
-			<form name="dexter_options" method="post" action="">
-				<?php wp_nonce_field( self::FORM_ACTION, 'pokemon_generation_nonce' ); ?>
-				<div class="form-field">
-					<label for="pokemon_generation"><?php echo esc_html_e (' Show until which generation?', 'wp-dexter' ); ?> </label>
-					<select name="pokemon_generation">
-						<?php $this->plugin->components->api->pokemon_list(); ?>
-					</select>
-				</div>
-				<div class="form-field">
-					<?php submit_button( esc_html( 'Save changes', 'wp-dexter' ) ); ?>
-				</div>
-				<p><?php echo esc_html_e( 'Currently picking up from:', 'wp-dexter' ); ?> <span class="pokebold"><?php echo esc_html( sprintf( __( '%s Pokemon', 'wp-dexter' ), $wp_dexter_pokemon_generation ) ); ?></span></p>
-			</form>
-			<?php
-		$this->process_form_settings();
+		include( dirname( __FILE__ ) . '/../templates/settings-page.php' );
 	}
 
 	/**

--- a/templates/settings-page.php
+++ b/templates/settings-page.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Dexter's settings page
+ *
+ * @package WpDexter
+ */
+
+namespace WpDexter;
+
+// Check referrer.
+if ( ! ( $this instanceof Admin ) ) {
+	return;
+}
+
+$wp_dexter_pokemon_generation = get_option( 'wp_dexter_pokemon_generation' );
+?>
+<div class="wrap">
+	<h2><?php echo esc_html( $GLOBALS['title'] ); ?></h2>
+	<div class="pokepostbox postbox">
+		<h3><?php echo esc_html_e( 'Settings', 'wp-dexter' ); ?></h3>
+		<p><?php echo esc_html_e( 'Currently picking up from:', 'wp-dexter' ); ?> <span class="pokebold"><?php echo esc_html( sprintf( __( '%s Pokemon', 'wp-dexter' ), $wp_dexter_pokemon_generation ) ); ?></span></p>
+		<form name="dexter_options" method="post" action="<?php admin_url( 'admin-post.php' ); ?>">
+			<?php wp_nonce_field( self::FORM_ACTION, 'pokemon_generation_nonce' ); ?>
+			<label for="pokemon_generation"><?php echo esc_html_e( ' Show until which generation?', 'wp-dexter' ); ?></label>
+			<select name="pokemon_generation">
+				<?php $this->plugin->components->api->pokemon_list(); ?>
+			</select>
+			<?php submit_button( esc_html( 'Save changes', 'wp-dexter' ) ); ?>
+		</form>
+	</div>
+</div>
+<?php
+$this->process_form_settings();


### PR DESCRIPTION
This PR addresses issue #2 ,

Changes in this PR

- Removes the pokémon metabox showed in settings page
- Moves Dexter from the main dashboard to the settings menu and adds a submenu to manage Dexter settings from there. 
- Improves the settings page markup.
- Improves the styling of the settings page.